### PR TITLE
set opacity on resize handler

### DIFF
--- a/src/js/kickbox.js
+++ b/src/js/kickbox.js
@@ -420,6 +420,10 @@ function addClusterLayer(map, options) {
  * @param {Object} the layer to re-add
 */
 function _readdWmsLayer(map, layerParams, options) {
+  const opacity = map.getPaintProperty(
+    options.layerId + '-layer',
+    'raster-opacity'
+  );
   helper.removeLayer(map, options.layerId + '-layer');
   helper.removeSource(map, options.layerId + '-source');
 
@@ -428,6 +432,7 @@ function _readdWmsLayer(map, layerParams, options) {
   layerParams.height = dims.height;
   layerParams.width = dims.width;
   helper.bindWmsToSource(map, options.wmsUrl, options.layerId, layerParams, options);
+  setLayerOpacity(map, options.layerId, opacity);
 }
 
 /**


### PR DESCRIPTION
When resizing the window, or resizing the mapbox div, the opacity gets reset to 1. This fixes the problem by resetting the opacity after readding the layer.